### PR TITLE
Fix deprecation warning on unlink

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function hitThat (url, options) {
       fs.createReadStream(name).pipe(tube).on('end', remove);
     }
     function remove () {
-     fs.unlink(name);
+     fs.unlinkSync(name);
     }
   }
 }


### PR DESCRIPTION
Using this tool with NodeJS 7.x installed causes a deprecation warning:

    (node:5088) DeprecationWarning: Calling an asynchronous function without callback is deprecated.

Which is caused by using `fs.unlink` without a callback. Fixed by using unlinkSync instead.